### PR TITLE
Adding pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+      - id: check-ast
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+        args: [--fix, lf]
+      - id: name-tests-test
+        args: [--django]
+  - repo: local
+    hooks:
+      - id: unittest
+        name: unittest
+        entry: python -m unittest discover 
+        language: python
+        types: [python]
+        pass_filenames: false
+        stages: [commit]
+        additional_dependencies: [pydot]
+        always_run: true


### PR DESCRIPTION
Hi there,
after issue #22 I thought an easy way of preventing pushing such errors to pypi would be to automatically run the unittests on every commit.

This can either be done using CI/CD using a [GitHub ci-cd pipline](https://resources.github.com/ci-cd/) which could be run after every commit by GitHub in the cloud.

Alternatively, they can be run *locally* before every commit. A great tool to do this easily is [pre-commit](https://pre-commit.com/).
It allows to install pre-commit hooks into your local git infrastructure to run any number of commands before any commit.
If any of them fail, the commit will be aborted and the issue can be resolved locally.

This PR adds a basic pre-commit configuration including checking:
* if .py files are syntactically valid python
* if any files have names that would conflict on a case-insensitive filesystem
* if any files contain strings from merge conflicts
* if any files have CRLF file endings instea of LF. These will be automatically changed to LF
* if .py files in tests/ start with test*.py
* Finally, the unittests will be executed using `python -m unittest discover`.
To make them discoverable, I added a dunder-init file in tests.

However, at the moment the unittests use **relative file paths** that break when running them from the project root folder.
Additionally, they are pretty slow. If unittests should be run on every commit, the tests would have to be **faster** than they currently are, or alternatively be curated to only include fast ones.
Please check this out before accepting this PR!


**Fast setup for pre-commit:**
Install it by using `pip install pre-commit`.
Then type `pre-commit install` to install the hooks them into the local git repository.
Run the hooks on the *entire project* by using `pre-commit run -a`.

By default, commits will only run on *changed files* instead of the entire project.
You can manually run the hooks on *only changed files* using `pre-commit run`.

