### PR TITLE
Problems saving and loaded certain Moore machines

### DIFF
--- a/aalpy/automata/Dfa.py
+++ b/aalpy/automata/Dfa.py
@@ -39,9 +39,6 @@ class Dfa(DeterministicAutomaton):
                                                              online_suffix_closure, split_all_blocks,
                                                              return_same_states, raise_warning)
 
-    def is_minimal(self):
-        return self.compute_characterization_set(raise_warning=False) is not None
-
     def compute_output_seq(self, state, sequence):
         if not sequence:
             return [state.is_accepting]

--- a/aalpy/automata/MealyMachine.py
+++ b/aalpy/automata/MealyMachine.py
@@ -32,9 +32,6 @@ class MealyMachine(DeterministicAutomaton):
         self.current_state = self.current_state.transitions[letter]
         return output
 
-    def is_minimal(self):
-        return self.compute_characterization_set(raise_warning=False) is not None
-
     def to_state_setup(self):
         state_setup_dict = {}
 

--- a/aalpy/automata/MooreMachine.py
+++ b/aalpy/automata/MooreMachine.py
@@ -39,9 +39,6 @@ class MooreMachine(DeterministicAutomaton):
                                                                       online_suffix_closure, split_all_blocks,
                                                                       return_same_states, raise_warning)
 
-    def is_minimal(self):
-        return self.compute_characterization_set(raise_warning=False) is not None
-
     def compute_output_seq(self, state, sequence):
         if not sequence:
             return [state.output]

--- a/aalpy/base/Automaton.py
+++ b/aalpy/base/Automaton.py
@@ -2,6 +2,7 @@ import copy
 import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from typing import Optional
 
 
 class AutomatonState(ABC):
@@ -153,7 +154,7 @@ class DeterministicAutomaton(Automaton):
     def step(self, letter):
         pass
 
-    def get_shortest_path(self, origin_state: AutomatonState, target_state: AutomatonState) -> tuple:
+    def get_shortest_path(self, origin_state: AutomatonState, target_state: AutomatonState) -> Optional[tuple]:
         """
         Breath First Search over the automaton
 
@@ -164,12 +165,11 @@ class DeterministicAutomaton(Automaton):
 
         Returns:
 
-            sequence of inputs that lead from origin_state to target state
+            sequence of inputs that lead from origin_state to target state or None if no path exists
 
         """
         if origin_state not in self.states or target_state not in self.states:
-            warnings.warn('Origin or target state not in automaton. Returning empty path.')
-            return ()
+            raise ValueError('Origin or target state not in automaton.')
 
         explored = []
         queue = [[origin_state]]
@@ -197,7 +197,7 @@ class DeterministicAutomaton(Automaton):
 
                 # mark node as explored
                 explored.append(node)
-        return ()
+        return None
 
     def is_strongly_connected(self) -> bool:
         """

--- a/aalpy/base/Automaton.py
+++ b/aalpy/base/Automaton.py
@@ -2,7 +2,6 @@ import copy
 import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import Optional
 
 
 class AutomatonState(ABC):
@@ -154,7 +153,7 @@ class DeterministicAutomaton(Automaton):
     def step(self, letter):
         pass
 
-    def get_shortest_path(self, origin_state: AutomatonState, target_state: AutomatonState) -> Optional[tuple]:
+    def get_shortest_path(self, origin_state: AutomatonState, target_state: AutomatonState) -> tuple:
         """
         Breath First Search over the automaton
 
@@ -165,11 +164,12 @@ class DeterministicAutomaton(Automaton):
 
         Returns:
 
-            sequence of inputs that lead from origin_state to target state or None if no path exists
+            sequence of inputs that lead from origin_state to target state
 
         """
         if origin_state not in self.states or target_state not in self.states:
-            raise ValueError('Origin or target state not in automaton.')
+            warnings.warn('Origin or target state not in automaton. Returning empty path.')
+            return ()
 
         explored = []
         queue = [[origin_state]]
@@ -197,7 +197,7 @@ class DeterministicAutomaton(Automaton):
 
                 # mark node as explored
                 explored.append(node)
-        return None
+        return ()
 
     def is_strongly_connected(self) -> bool:
         """

--- a/aalpy/base/Automaton.py
+++ b/aalpy/base/Automaton.py
@@ -1,3 +1,5 @@
+import copy
+import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict
 
@@ -166,7 +168,6 @@ class DeterministicAutomaton(Automaton):
 
         """
         if origin_state not in self.states or target_state not in self.states:
-            import warnings
             warnings.warn('Origin or target state not in automaton. Returning empty path.')
             return ()
 
@@ -280,7 +281,12 @@ class DeterministicAutomaton(Automaton):
         return output
 
     def is_minimal(self):
-        pass
+        mm = self
+        if not self.is_input_complete():
+            warnings.warn("Automaton is not input-complete: Checking minimality may take longer")
+            mm = copy.deepcopy(self)
+            mm.make_input_complete("sink_state")
+        return mm.compute_characterization_set(raise_warning=False) is not None
 
     def compute_characterization_set(self, char_set_init=None,
                                      online_suffix_closure=True,
@@ -311,10 +317,8 @@ class DeterministicAutomaton(Automaton):
         Returns: a characterization set or None if a non-minimal automaton is passed to the function
 
         """
-        from copy import copy
-
         blocks = list()
-        blocks.append(copy(self.states))
+        blocks.append(copy.copy(self.states))
         char_set = [] if not char_set_init else char_set_init
         if char_set_init:
             for seq in char_set_init:
@@ -337,7 +341,6 @@ class DeterministicAutomaton(Automaton):
                     return split_state1, split_state2
 
                 if raise_warning:
-                    import warnings
                     warnings.warn("Automaton is non-canonical: could not compute characterization set."
                                   "Returning None.")
                 return None

--- a/aalpy/utils/FileHandler.py
+++ b/aalpy/utils/FileHandler.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import traceback
+from pathlib import Path
 
 from pydot import Dot, Node, Edge, graph_from_dot_file
 
@@ -140,7 +141,7 @@ def save_automaton_to_file(automaton, path="LearnedModel", file_type='dot',
         display_same_state_trans = True
     automaton_type = automaton_types[automaton.__class__]
 
-    graph = Dot(path, graph_type='digraph')
+    graph = Dot(Path(path).name, graph_type='digraph')
     for state in automaton.states:
         graph.add_node(_get_node(state, automaton_type))
 

--- a/aalpy/utils/FileHandler.py
+++ b/aalpy/utils/FileHandler.py
@@ -83,7 +83,7 @@ def _add_transition_to_graph(graph, state, automaton_type, display_same_state_tr
                 graph.add_edge(Edge(state.state_id, s[0].state_id, label=_wrap_label(f'{i}/{s[1]}:{prob}')))
 
 
-def visualize_automaton(automaton, path="LearnedModel", file_type='pdf', display_same_state_trans=True):
+def visualize_automaton(automaton, path="LearnedModel", file_type="pdf", display_same_state_trans=True):
     """
     Create a graphical representation of the automaton.
     Function is round in the separate thread in the background.
@@ -93,9 +93,9 @@ def visualize_automaton(automaton, path="LearnedModel", file_type='pdf', display
 
         automaton: automaton to be visualized
 
-        path: file in which visualization will be saved (Default value = "Model_Visualization")
+        path: pathlike or str, file in which visualization will be saved (Default value = "LearnedModel.pdf")
 
-        file_type: type of file/visualization. Can be ['png', 'svg', 'pdf'] (Default value = 'pdf')
+        file_type: type of file/visualization. Can be ['png', 'svg', 'pdf'] (Default value = "pdf")
 
         display_same_state_trans: if True, same state transitions will be displayed (Default value = True)
 
@@ -111,7 +111,7 @@ def visualize_automaton(automaton, path="LearnedModel", file_type='pdf', display
     visualization_thread.start()
 
 
-def save_automaton_to_file(automaton, path="LearnedModel", file_type='dot',
+def save_automaton_to_file(automaton, path="LearnedModel", file_type="dot",
                            display_same_state_trans=True, visualize=False, round_floats=None):
     """
     The Standard of the automata strictly follows the syntax found at: https://automata.cs.ru.nl/Syntax/Overview.
@@ -121,9 +121,9 @@ def save_automaton_to_file(automaton, path="LearnedModel", file_type='dot',
 
         automaton: automaton to be saved to file
 
-        path: file in which automaton will be saved (Default value = "LearnedModel")
+        path: pathlike or str, file in which visualization will be saved (Default value = "LearnedModel")
 
-        file_type: Can be ['dot', 'png', 'svg', 'pdf'] (Default value = 'dot')
+        file_type: type of file/visualization. Can be ['dot', 'png', 'svg', 'pdf'] (Default value = "dot)
 
         display_same_state_trans: True, should not be set to false except from the visualization method
             (Default value = True)
@@ -135,13 +135,16 @@ def save_automaton_to_file(automaton, path="LearnedModel", file_type='dot',
     Returns:
 
     """
-    assert file_type in file_types
+    path = Path(path)
+    file_type = file_type.lower()
+    assert file_type in file_types, f"Filetype {file_type} not in allowed filetypes"
+    path = path.with_suffix(f".{file_type}")
     if file_type == 'dot' and not display_same_state_trans:
         print("When saving to file all transitions will be saved")
         display_same_state_trans = True
     automaton_type = automaton_types[automaton.__class__]
 
-    graph = Dot(Path(path).name, graph_type='digraph')
+    graph = Dot(path.stem, graph_type='digraph')
     for state in automaton.states:
         graph.add_node(_get_node(state, automaton_type))
 
@@ -156,21 +159,19 @@ def save_automaton_to_file(automaton, path="LearnedModel", file_type='dot',
         return graph.to_string()
     else:
         try:
-            graph.write(path=f'{path}.{file_type}', format=file_type if file_type != 'dot' else 'raw')
-            print(f'Model saved to {path}.{file_type}.')
+            graph.write(path=path, format=file_type if file_type != 'dot' else 'raw')
+            print(f'Model saved to {path.as_posix()}.')
 
             if visualize and file_type in {'pdf', 'png', 'svg'}:
                 try:
                     import webbrowser
-                    abs_path = os.path.abspath(f'{path}.{file_type}')
-                    path = f'file:///{abs_path}'
-                    webbrowser.open(path)
+                    webbrowser.open(path.resolve().as_uri())
                 except OSError:
                     traceback.print_exc()
-                    print(f'Could not open the file {path}.{file_type}.', file=sys.stderr)
+                    print(f'Could not open the file {path.as_posix()}.', file=sys.stderr)
         except OSError:
             traceback.print_exc()
-            print(f'Could not write to the file {path}.{file_type}.', file=sys.stderr)
+            print(f'Could not write to the file {path.as_posix()}.', file=sys.stderr)
 
 
 def _process_label(label, source, destination, automaton_type):
@@ -238,7 +239,7 @@ def load_automaton_from_file(path, automaton_type, compute_prefixes=False):
 
     Args:
 
-        path: path to the file
+        path: pathlike or str to the file
 
         automaton_type: type of the automaton, if not specified it will be automatically determined according,
             one of ['dfa', 'mealy', 'moore', 'mdp', 'smm', 'onfsm', 'mc']
@@ -250,6 +251,7 @@ def load_automaton_from_file(path, automaton_type, compute_prefixes=False):
       automaton
 
     """
+    path = Path(path)
     graph = graph_from_dot_file(path)[0]
 
     assert automaton_type in automaton_types.values()

--- a/aalpy/utils/FileHandler.py
+++ b/aalpy/utils/FileHandler.py
@@ -209,8 +209,7 @@ def _process_node_label(node, label, node_label_dict, node_type, automaton_type)
     else:
         if automaton_type == 'moore' and label != "":
             label_output = _strip_label(label)
-            label = label_output.split('|')[0]
-            output = label_output.split('|')[1]
+            label, output = label_output.split("|", maxsplit=1)
             output = output if not output.isdigit() else int(output)
             node_label_dict[node_name] = node_type(label, output)
         else:


### PR DESCRIPTION
I ran into some trouble saving Moore machines and trying to load them again.
One problem was that slashes in the name of the digraph node in .dot was considered a parsing error by pydot.
And secondly if the output of a MooreState contained a "|" symbol it would not parse this, which is now fixed.