### PR TITLE
Fix RPNI compatible outputs function

### DIFF
--- a/aalpy/learning_algs/deterministic_passive/rpni_helper_functions.py
+++ b/aalpy/learning_algs/deterministic_passive/rpni_helper_functions.py
@@ -38,8 +38,8 @@ class RpniNode:
         if self.type != 'mealy':
             return self.output == other.output or self.output is None or other.output is None
         else:
-            red_io = {i: o for i, o in self.children.keys()}
-            blue_io = {i: o for i, o in other.children.keys()}
+            red_io = {i: o for i, o in self.output.items()}
+            blue_io = {i: o for i, o in other.output.items()}
             for common_i in set(red_io.keys()).intersection(blue_io.keys()):
                 if red_io[common_i] != blue_io[common_i]:
                     return False


### PR DESCRIPTION
Hello, I am Jun Park, and I am interested in your project.

I have been closely inspecting your project or other project used AALpy, particularly from BLE passive learning to AALpy.

However, I have found some bugs in the 3788ea4 commit.

I believe there is an incorrect patch in the compatible_outputs function in this commit.

Specifically, I think the code could be modified as follows:

![image](https://github.com/user-attachments/assets/734e7294-c34b-4733-b2e5-11e3dcc18573)


And my the test unit are data and data2 array.
```
def rpni_mealy_example2():
    import random
    from aalpy.learning_algs import run_RPNI
    from aalpy.utils import generate_random_deterministic_automata
    from aalpy.utils.HelperFunctions import all_prefixes, convert_i_o_traces_for_RPNI
    # make reproducible
    random.seed(1)
    data = [
        [('a','x'),('a','x'),('b','y')],
        [('b','y'),('a','z'),('a','z')]
    ]
    data2 = [
        [('1','a'),('2','b'),('3','c')],
        [('6','7'),('4','e'),('3','c')]
    ]
    data = convert_i_o_traces_for_RPNI(data)
    rpni_model = run_RPNI(data, automaton_type='mealy', print_info=True)

    return rpni_model
rpni_mealy_example2().visualize()
```

The expected mealy machine is this. But the results got from current version is something wrong.
![image](https://github.com/user-attachments/assets/e582f678-0a48-4149-aebc-0a21526b0400)
