### PR TITLE
optimized the W and Wp method oracles

### DIFF
--- a/aalpy/oracles/WpMethodEqOracle.py
+++ b/aalpy/oracles/WpMethodEqOracle.py
@@ -1,8 +1,7 @@
-from itertools import chain, tee
+from itertools import chain, tee, product
 
 from aalpy.base.Oracle import Oracle
 from aalpy.base.SUL import SUL
-from aalpy.utils.HelperFunctions import product_with_possible_empty_iterable
 
 
 def state_characterization_set(hypothesis, alphabet, state):
@@ -23,15 +22,6 @@ def state_characterization_set(hypothesis, alphabet, state):
     return result
 
 
-def i_star(alphabet, max_seq_len):
-    """
-    Return an iterator that generates all possible sequences of length upto from the given alphabet.
-    Args:
-        alphabet: input alphabet
-        max_seq_len: maximum length of the sequences
-    """
-    return chain(*(product_with_possible_empty_iterable(alphabet, repeat=i) for i in range(max_seq_len)))
-
 def first_phase_it(alphabet, state_cover, depth, char_set):
     """
     Return an iterator that generates all possible sequences for the first phase of the Wp-method.
@@ -41,11 +31,12 @@ def first_phase_it(alphabet, state_cover, depth, char_set):
         depth: maximum length of middle part
         char_set: characterization set
     """
+    char_set = char_set or [()]
     for d in range(depth):
-        middle = product_with_possible_empty_iterable(alphabet, repeat=d)
+        middle = product(alphabet, repeat=d)
         for m in middle:
-            for case in product_with_possible_empty_iterable(state_cover, [m], char_set):
-                yield case
+            for (s, c) in product(state_cover, char_set):
+                yield s + m + c
 
 def second_phase_it(hyp, alphabet, difference, depth):
     """
@@ -58,15 +49,15 @@ def second_phase_it(hyp, alphabet, difference, depth):
     """
     state_mapping = {}
     for d in range(depth):
-        middle = product_with_possible_empty_iterable(alphabet, repeat=d)
-        for t, mid in product_with_possible_empty_iterable(difference, middle):
+        middle = product(alphabet, repeat=d)
+        for t, mid in product(difference, middle):
             _ = hyp.execute_sequence(hyp.initial_state, t + mid)
             state = hyp.current_state
             if state not in state_mapping:
                 state_mapping[state] = state_characterization_set(hyp, alphabet, state)
 
             for sm in state_mapping[state]:
-                yield (t,) + (mid,) + (sm,)
+                yield t + mid + sm
 
 
 class WpMethodEqOracle(Oracle):
@@ -83,16 +74,14 @@ class WpMethodEqOracle(Oracle):
         if not hypothesis.characterization_set:
             hypothesis.characterization_set = hypothesis.compute_characterization_set()
 
-        # keep this as a list, because we only iterate over it
-        transition_cover = [
+        transition_cover = set(
             state.prefix + (letter,)
             for state in hypothesis.states
             for letter in self.alphabet
-        ]
+        )
 
-        state_cover = [state.prefix for state in hypothesis.states]
-        # make the state cover a set for faster lookup
-        difference = [tc for tc in transition_cover if tc not in set(state_cover)]
+        state_cover = set(state.prefix for state in hypothesis.states)
+        difference = transition_cover.difference(state_cover)
         depth = self.m + 1 - len(hypothesis.states)
         # first phase State Cover * Middle * Characterization Set
         first_phase = first_phase_it(self.alphabet, state_cover, depth, hypothesis.characterization_set)
@@ -103,8 +92,6 @@ class WpMethodEqOracle(Oracle):
         test_suite = chain(first_phase, second_phase)
 
         for seq in test_suite:
-            seq = tuple([i for sub in seq for i in sub])
-
             if seq not in self.cache:
                 self.reset_hyp_and_sul(hypothesis)
 

--- a/aalpy/oracles/WpMethodEqOracle.py
+++ b/aalpy/oracles/WpMethodEqOracle.py
@@ -51,8 +51,8 @@ def second_phase_it(hyp, alphabet, difference, depth):
     state_mapping = {}
     for d in range(depth):
         middle = product(alphabet, repeat=d)
-        for t in difference:
-            for mid in middle:
+        for mid in middle:
+            for t in difference:
                 _ = hyp.execute_sequence(hyp.initial_state, t + mid)
                 state = hyp.current_state
                 if state not in state_mapping:

--- a/aalpy/oracles/WpMethodEqOracle.py
+++ b/aalpy/oracles/WpMethodEqOracle.py
@@ -35,8 +35,9 @@ def first_phase_it(alphabet, state_cover, depth, char_set):
     for d in range(depth):
         middle = product(alphabet, repeat=d)
         for m in middle:
-            for (s, c) in product(state_cover, char_set):
-                yield s + m + c
+            for s in state_cover:
+                for c in char_set:
+                    yield s + m + c
 
 def second_phase_it(hyp, alphabet, difference, depth):
     """
@@ -50,14 +51,15 @@ def second_phase_it(hyp, alphabet, difference, depth):
     state_mapping = {}
     for d in range(depth):
         middle = product(alphabet, repeat=d)
-        for t, mid in product(difference, middle):
-            _ = hyp.execute_sequence(hyp.initial_state, t + mid)
-            state = hyp.current_state
-            if state not in state_mapping:
-                state_mapping[state] = state_characterization_set(hyp, alphabet, state)
+        for t in difference:
+            for mid in middle:
+                _ = hyp.execute_sequence(hyp.initial_state, t + mid)
+                state = hyp.current_state
+                if state not in state_mapping:
+                    state_mapping[state] = state_characterization_set(hyp, alphabet, state)
 
-            for sm in state_mapping[state]:
-                yield t + mid + sm
+                for sm in state_mapping[state]:
+                    yield t + mid + sm
 
 
 class WpMethodEqOracle(Oracle):

--- a/aalpy/oracles/WpMethodEqOracle.py
+++ b/aalpy/oracles/WpMethodEqOracle.py
@@ -32,25 +32,41 @@ def i_star(alphabet, max_seq_len):
     """
     return chain(*(product_with_possible_empty_iterable(alphabet, repeat=i) for i in range(max_seq_len)))
 
+def first_phase_it(alphabet, state_cover, depth, char_set):
+    """
+    Return an iterator that generates all possible sequences for the first phase of the Wp-method.
+    Args:
+        alphabet: input alphabet
+        state_cover: list of states to cover
+        depth: maximum length of middle part
+        char_set: characterization set
+    """
+    for d in range(depth):
+        middle = product_with_possible_empty_iterable(alphabet, repeat=d)
+        for m in middle:
+            for case in product_with_possible_empty_iterable(state_cover, [m], char_set):
+                yield case
 
-def second_phase_it(hyp, alphabet, difference, middle):
+def second_phase_it(hyp, alphabet, difference, depth):
     """
     Return an iterator that generates all possible sequences for the second phase of the Wp-method.
     Args:
         hyp: hypothesis automaton
         alphabet: input alphabet
         difference: set of sequences that are in the transition cover but not in the state cover
-        middle: iterator that generates all possible sequences of length upto from the given alphabet
+        depth: maximum length of middle part
     """
     state_mapping = {}
-    for t, mid in product_with_possible_empty_iterable(difference, middle):
-        _ = hyp.execute_sequence(hyp.initial_state, t + mid)
-        state = hyp.current_state
-        if state not in state_mapping:
-            state_mapping[state] = state_characterization_set(hyp, alphabet, state)
+    for d in range(depth):
+        middle = product_with_possible_empty_iterable(alphabet, repeat=d)
+        for t, mid in product_with_possible_empty_iterable(difference, middle):
+            _ = hyp.execute_sequence(hyp.initial_state, t + mid)
+            state = hyp.current_state
+            if state not in state_mapping:
+                state_mapping[state] = state_characterization_set(hyp, alphabet, state)
 
-        for sm in state_mapping[state]:
-            yield (t,) + (mid,) + (sm,)
+            for sm in state_mapping[state]:
+                yield (t,) + (mid,) + (sm,)
 
 
 class WpMethodEqOracle(Oracle):
@@ -67,24 +83,23 @@ class WpMethodEqOracle(Oracle):
         if not hypothesis.characterization_set:
             hypothesis.characterization_set = hypothesis.compute_characterization_set()
 
-        transition_cover = set(
+        # keep this as a list, because we only iterate over it
+        transition_cover = [
             state.prefix + (letter,)
             for state in hypothesis.states
             for letter in self.alphabet
-        )
+        ]
 
-        state_cover = set(state.prefix for state in hypothesis.states)
-        difference = transition_cover.difference(state_cover)
-
-        # two views of the same iterator
-        middle_1, middle_2 = tee(i_star(self.alphabet, self.m - hypothesis.size + 1), 2)
-
+        state_cover = [state.prefix for state in hypothesis.states]
+        # make the state cover a set for faster lookup
+        difference = [tc for tc in transition_cover if tc not in set(state_cover)]
+        depth = self.m + 1 - len(hypothesis.states)
         # first phase State Cover * Middle * Characterization Set
-        first_phase = product_with_possible_empty_iterable(state_cover, middle_1, hypothesis.characterization_set)
+        first_phase = first_phase_it(self.alphabet, state_cover, depth, hypothesis.characterization_set)
 
         # second phase (Transition Cover - State Cover) * Middle * Characterization Set
         # of the state that the prefix leads to
-        second_phase = second_phase_it(hypothesis, self.alphabet, difference, middle_2)
+        second_phase = second_phase_it(hypothesis, self.alphabet, difference, depth)
         test_suite = chain(first_phase, second_phase)
 
         for seq in test_suite:

--- a/aalpy/oracles/WpMethodOther.py
+++ b/aalpy/oracles/WpMethodOther.py
@@ -1,0 +1,119 @@
+from itertools import chain, tee, product
+
+from aalpy.base.Oracle import Oracle
+from aalpy.base.SUL import SUL
+from aalpy.utils.HelperFunctions import product_with_possible_empty_iterable
+
+
+def state_characterization_set(hypothesis, alphabet, state):
+    """
+    Return a list of sequences that distinguish the given state from all other states in the hypothesis.
+    Args:
+        hypothesis: hypothesis automaton
+        alphabet: input alphabet
+        state: state for which to find distinguishing sequences
+    """
+    result = []
+    for i in range(len(hypothesis.states)):
+        if hypothesis.states[i] == state:
+            continue
+        seq = hypothesis.find_distinguishing_seq(state, hypothesis.states[i], alphabet)
+        if seq:
+            result.append(tuple(seq))
+    return result
+
+
+def i_star(alphabet, max_seq_len):
+    """
+    Return an iterator that generates all possible sequences of length upto from the given alphabet.
+    Args:
+        alphabet: input alphabet
+        max_seq_len: maximum length of the sequences
+    """
+    return chain(*(product_with_possible_empty_iterable(alphabet, repeat=i) for i in range(max_seq_len)))
+
+
+def second_phase_test_case_generator(hyp, alphabet, difference, middle):
+    """
+    Return an iterator that generates all possible sequences for the second phase of the Wp-method.
+    Args:
+        hyp: hypothesis automaton
+        alphabet: input alphabet
+        difference: set of sequences that are in the transition cover but not in the state cover
+        middle: iterator that generates all possible sequences of length upto from the given alphabet
+    """
+    state_mapping = {}
+    for t, mid in product_with_possible_empty_iterable(difference, middle):
+        _ = hyp.execute_sequence(hyp.initial_state, t + mid)
+        state = hyp.current_state
+        if state not in state_mapping:
+            state_mapping[state] = state_characterization_set(hyp, alphabet, state)
+
+        for sm in state_mapping[state]:
+            yield t + mid + sm
+
+
+class WpMethodOtherEqOracle(Oracle):
+    """
+    Implements the Wp-method equivalence oracle.
+    """
+
+    def __init__(self, alphabet: list, sul: SUL, max_number_of_states=4):
+        super().__init__(alphabet, sul)
+        self.m = max_number_of_states
+        self.cache = set()
+
+    def test_sequance(self, hypothesis, seq_under_test):
+        self.reset_hyp_and_sul(hypothesis)
+
+        for ind, letter in enumerate(seq_under_test):
+            out_hyp = hypothesis.step(letter)
+            out_sul = self.sul.step(letter)
+            self.num_steps += 1
+
+            if out_hyp != out_sul:
+                self.sul.post()
+                return seq_under_test[: ind + 1]
+        self.cache.add(seq_under_test)
+
+        return None
+
+    def find_cex(self, hypothesis):
+        if not hypothesis.characterization_set:
+            hypothesis.characterization_set = hypothesis.compute_characterization_set()
+
+        transition_cover = set(
+            state.prefix + (letter,)
+            for state in hypothesis.states
+            for letter in self.alphabet
+        )
+
+        state_cover = set(state.prefix for state in hypothesis.states)
+        difference = transition_cover.difference(state_cover)
+
+        # two views of the same iterator
+        middle_1, middle_2 = tee(i_star(self.alphabet, self.m - hypothesis.size + 1), 2)
+
+        # first phase State Cover * Middle * Characterization Set
+        state_cover = state_cover or [()]
+        char_set = hypothesis.characterization_set or [()]
+
+        for sc in state_cover:
+            for m in middle_1:
+                for cs in char_set:
+                    test_seq = sc + m + cs
+                    if test_seq not in self.cache:
+                        counterexample = self.test_sequance(hypothesis, test_seq)
+                        if counterexample:
+                            return counterexample
+        # second phase (Transition Cover - State Cover) * Middle * Characterization Set
+        # of the state that the prefix leads to
+        second_phase = second_phase_test_case_generator(hypothesis, self.alphabet, difference, middle_2)
+
+        for test_seq in second_phase:
+            if test_seq not in self.cache:
+                counterexample = self.test_sequance(hypothesis, test_seq)
+                if counterexample:
+                    return counterexample
+
+        return None


### PR DESCRIPTION
My attempt at optimizing the W and Wp methods.

The memory taken up by the `middle` part is reduced by `yielding` from it in both the `first phase` and `second phase`. Turns out that it hurts performance when including `middle` in `product`.

Another difference is that the top iteration is performed on the `middle` part, in order to search in big depths only if no counterexample if found in small depths.

Finally, these ideas can be applied to the W method too, as it suffered from the same problems.

The implementation on the master branch right now is wrong because the oracle does not actually iterate over the `middle` more than once, because `middle` is exhausted after the first iteration. It just so happens that all counter examples are found without needing to iterate over the `middle` more than once.