### PR TITLE
Improved GSM performance

### DIFF
--- a/aalpy/learning_algs/general_passive/GeneralizedStateMerging.py
+++ b/aalpy/learning_algs/general_passive/GeneralizedStateMerging.py
@@ -3,7 +3,7 @@ from collections import deque
 from typing import Dict, Tuple, Callable, List, Optional
 
 from aalpy.learning_algs.general_passive.GsmNode import GsmNode, OutputBehavior, TransitionBehavior, TransitionInfo, \
-    OutputBehaviorRange, TransitionBehaviorRange, intersection_iterator, NodeOrders, unknown_output, detect_data_format
+    OutputBehaviorRange, TransitionBehaviorRange, intersection_iterator, unknown_output, detect_data_format
 from aalpy.learning_algs.general_passive.ScoreFunctionsGSM import ScoreCalculation, hoeffding_compatibility
 
 
@@ -69,9 +69,7 @@ class GeneralizedStateMerging:
         self.score_calc: ScoreCalculation = score_calc
 
         if node_order is None:
-            node_order = NodeOrders.Default
-        if node_order is NodeOrders.NoCompare or node_order is NodeOrders.Default:
-            self.node_order = node_order
+            self.node_order = GsmNode.default_order
         else:
             self.node_order = functools.cmp_to_key(lambda a, b: -1 if node_order(a, b) else 1)
 
@@ -119,6 +117,10 @@ class GeneralizedStateMerging:
 
         partition_candidates: Dict[Tuple[GsmNode, GsmNode], Partitioning] = dict()
         while True:
+            # sort states. states are always sorted using default order on original prefix
+            if self.node_order is not GsmNode.default_order:
+                red_states.sort(key=self.node_order)
+
             # get blue states
             blue_states = []
             for r in red_states:
@@ -127,17 +129,16 @@ class GeneralizedStateMerging:
                     if c in red_states:
                         continue
                     blue_states.append(c)
-                    if self.consider_only_min_blue or not self.score_calc.has_score_function():
-                        blue_states = [min(blue_states, key=self.node_order)]
+                    if self.consider_only_min_blue and self.node_order is GsmNode.default_order:
+                        break
 
             # no blue states left -> done
             if len(blue_states) == 0:
                 break
-            if self.node_order is not NodeOrders.NoCompare:
+            if self.consider_only_min_blue: # does it make sense to check the score function here?
+                blue_states = [min(blue_states, key=self.node_order)]
+            if self.node_order is not GsmNode.default_order:
                 blue_states.sort(key=self.node_order)
-                # red states are always sorted using default order on original prefix
-                if self.node_order is not NodeOrders.Default:
-                    red_states.sort(key=self.node_order)
 
             # loop over blue states
             promotion = False

--- a/aalpy/learning_algs/general_passive/GeneralizedStateMerging.py
+++ b/aalpy/learning_algs/general_passive/GeneralizedStateMerging.py
@@ -237,12 +237,11 @@ class GeneralizedStateMerging:
                 return red_node
         else:
             def update_partition(red_node: GsmNode, blue_node: Optional[GsmNode]) -> GsmNode:
-                if red_node not in partitioning.full_mapping:
+                p = partitioning.full_mapping.get(red_node) # could check smaller .red_mapping?
+                if p is None:
                     p = red_node.shallow_copy()
                     partitioning.full_mapping[red_node] = p
                     partitioning.red_mapping[red_node] = p
-                else:
-                    p = partitioning.full_mapping[red_node]
                 if blue_node is not None:
                     partitioning.full_mapping[blue_node] = p
                 return p

--- a/aalpy/learning_algs/general_passive/GeneralizedStateMerging.py
+++ b/aalpy/learning_algs/general_passive/GeneralizedStateMerging.py
@@ -269,7 +269,7 @@ class GeneralizedStateMerging:
 
             # create implied merges for all common successors
             for in_sym, blue_transitions in blue.transitions.items():
-                partition_transitions = partition.get_or_create_transitions(in_sym)
+                partition_transitions = partition.transitions[in_sym]
                 for out_sym, blue_transition in blue_transitions.items():
                     partition_transition = partition_transitions.get(out_sym)
                     # handle unknown output

--- a/aalpy/learning_algs/general_passive/GeneralizedStateMerging.py
+++ b/aalpy/learning_algs/general_passive/GeneralizedStateMerging.py
@@ -122,7 +122,7 @@ class GeneralizedStateMerging:
             # get blue states
             blue_states = []
             for r in red_states:
-                for _, t in r.transition_iterator():
+                for _, _, t in r.transition_iterator():
                     c = t.target
                     if c in red_states:
                         continue

--- a/aalpy/learning_algs/general_passive/GeneralizedStateMerging.py
+++ b/aalpy/learning_algs/general_passive/GeneralizedStateMerging.py
@@ -273,8 +273,8 @@ class GeneralizedStateMerging:
                 for out_sym, blue_transition in blue_transitions.items():
                     partition_transition = partition_transitions.get(out_sym)
                     # handle unknown output
-                    if partition_transition is None:
-                        if out_sym is unknown_output and len(partition_transitions) != 0:
+                    if partition_transition is None and len(partition_transitions) != 0:
+                        if out_sym is unknown_output:
                             assert len(partition_transitions) == 1
                             partition_transition = list(partition_transitions.values())[0]
                         if unknown_output in partition_transitions:

--- a/aalpy/learning_algs/general_passive/GsmNode.py
+++ b/aalpy/learning_algs/general_passive/GsmNode.py
@@ -1,6 +1,7 @@
 import functools
 import math
 import pathlib
+from collections import defaultdict
 from functools import total_ordering
 from typing import Dict, Any, List, Tuple, Iterable, Callable, Union, TypeVar, Iterator, Optional, Sequence
 import pydot
@@ -125,7 +126,7 @@ class GsmNode:
 
     def __init__(self, prefix_access_pair, predecessor: 'GsmNode' = None):
         # TODO try single dict
-        self.transitions: Dict[Any, Dict[Any, TransitionInfo]] = dict()
+        self.transitions: defaultdict[Any, Dict[Any, TransitionInfo]] = defaultdict(dict)
         self.predecessor: GsmNode = predecessor
         self.prefix_access_pair = prefix_access_pair
 
@@ -379,7 +380,7 @@ class GsmNode:
     def add_trace(self, trace: IOTrace):
         curr_node: GsmNode = self
         for in_sym, out_sym in trace:
-            transitions = curr_node.get_or_create_transitions(in_sym)
+            transitions = curr_node.transitions[in_sym]
             info = transitions.get(out_sym)
             if info is None:
                 node = GsmNode((in_sym, out_sym), curr_node)
@@ -397,7 +398,7 @@ class GsmNode:
 
         # step through inputs and add transitions
         for in_sym in inputs:
-            transitions = curr_node.get_or_create_transitions(in_sym)
+            transitions = curr_node.transitions[in_sym]
             t_infos = list(transitions.values())
             if len(t_infos) == 0:
                 node = GsmNode((in_sym, unknown_output), curr_node)

--- a/aalpy/learning_algs/general_passive/GsmNode.py
+++ b/aalpy/learning_algs/general_passive/GsmNode.py
@@ -188,7 +188,7 @@ class GsmNode:
             self.transitions[in_sym] = t
         return t
 
-    def transition_iterator(self) -> Iterable[Tuple[Tuple[Any, Any], TransitionInfo]]:
+    def transition_iterator(self) -> Iterable[Tuple[Any, Any, TransitionInfo]]:
         for in_sym, transitions in self.transitions.items():
             for out_sym, node in transitions.items():
                 yield in_sym, out_sym, node

--- a/aalpy/learning_algs/general_passive/GsmNode.py
+++ b/aalpy/learning_algs/general_passive/GsmNode.py
@@ -191,7 +191,7 @@ class GsmNode:
     def transition_iterator(self) -> Iterable[Tuple[Tuple[Any, Any], TransitionInfo]]:
         for in_sym, transitions in self.transitions.items():
             for out_sym, node in transitions.items():
-                yield (in_sym, out_sym), node
+                yield in_sym, out_sym, node
 
     def shallow_copy(self) -> 'GsmNode':
         node = GsmNode(self.prefix_access_pair, self.predecessor)
@@ -220,7 +220,7 @@ class GsmNode:
         result = [self]
         backing_set = {self}
         for state in result:
-            for _, transition in state.transition_iterator():
+            for _, _, transition in state.transition_iterator():
                 child = transition.target
                 if child not in backing_set:
                     backing_set.add(child)
@@ -232,7 +232,7 @@ class GsmNode:
         backing_set = {self}
         while len(q) != 0:
             current = q.pop(0)
-            for _, transition in current.transition_iterator():
+            for _, _, transition in current.transition_iterator():
                 child = transition.target
                 if child in backing_set:
                     return False
@@ -325,7 +325,7 @@ class GsmNode:
                     return f'{node.get_prefix_output()} {node.count()}'
             else:
                 def state_label(node: GsmNode):
-                    return f'{sum(t.count for _, t in node.transition_iterator())}'
+                    return f'{sum(t.count for _, _, t in node.transition_iterator())}'
         if trans_label is None and "label" not in trans_props:
             if output_behavior == "moore":
                 def trans_label(node: GsmNode, in_sym, out_sym):
@@ -464,7 +464,7 @@ class GsmNode:
 
     def is_moore(self):
         for node in self.get_all_nodes():
-            for (in_sym, out_sym), transition in node.transition_iterator():
+            for in_sym, out_sym, transition in node.transition_iterator():
                 child_output = transition.target.get_prefix_output()
                 if out_sym is not unknown_output and child_output != out_sym:
                     return False
@@ -487,7 +487,7 @@ class GsmNode:
         return llc
 
     def count(self):
-        return sum(trans.count for _, trans in self.transition_iterator())
+        return sum(trans.count for _, _, trans in self.transition_iterator())
 
 
 class NodeOrders:

--- a/aalpy/learning_algs/general_passive/GsmNode.py
+++ b/aalpy/learning_algs/general_passive/GsmNode.py
@@ -489,7 +489,4 @@ class GsmNode:
     def count(self):
         return sum(trans.count for _, _, trans in self.transition_iterator())
 
-
-class NodeOrders:
-    NoCompare = lambda n: 0
-    Default = functools.cmp_to_key(lambda a, b: -1 if a < b else 1)
+    default_order = functools.cmp_to_key(lambda a, b: -1 if a < b else 1)

--- a/aalpy/learning_algs/general_passive/GsmNode.py
+++ b/aalpy/learning_algs/general_passive/GsmNode.py
@@ -458,7 +458,7 @@ class GsmNode:
         for _, trans_self, trans_other in intersection_iterator(self.transitions, other.transitions):
             if unknown_output in trans_self or unknown_output in trans_other:
                 continue
-            if list(trans_self.keys()) != list(trans_other.keys()):
+            if trans_self.keys() != trans_other.keys():
                 return False
         return True
 

--- a/aalpy/learning_algs/general_passive/GsmNode.py
+++ b/aalpy/learning_algs/general_passive/GsmNode.py
@@ -196,9 +196,9 @@ class GsmNode:
     def shallow_copy(self) -> 'GsmNode':
         node = GsmNode(self.prefix_access_pair, self.predecessor)
         for in_sym, t in self.transitions.items():
-            d = dict()
-            for out_sym, v in t.items():
-                d[out_sym] = copy(v)
+            d = dict() # appears to be faster than dict comprehension
+            for out_sym, ti in t.items():
+                d[out_sym] = TransitionInfo(ti.target, ti.count, ti.original_target, ti.original_count)
             node.transitions[in_sym] = d
         return node
 


### PR DESCRIPTION
My measurement runs indicate that this reduces the runtime of GSM for RPNI by about 30%. I used the Abbadingo data as a benchmark. The main point was avoiding pythons `copy` while creating the partitions. Some other parts were improved. According to my profiling runs they should amount to about 5% or so, but the measurement runs without profiling are actually inconclusive. AFAIK there is no regression.